### PR TITLE
Use DELETE http verb (RESTful)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -213,7 +213,7 @@ uiModules
 
   $scope.deleteAlarm = function (index, rmindex, rmtype, rmid) {
     if (confirm('Delete is Forever!\n Are you sure?')) {
-      return $http.get('../api/sentinl/delete/alarm/' + rmindex + '/' + rmtype + '/' + rmid)
+      return $http.delete('../api/sentinl/alarm/' + rmindex + '/' + rmtype + '/' + rmid)
       .then(() => {
         $timeout(() => {
           $scope.elasticAlarms.splice(index - 1, 1);
@@ -306,7 +306,7 @@ uiModules
 
   $scope.watcherDelete = function ($index) {
     if (confirm('Are you sure?')) {
-      return $http.get('../api/sentinl/delete/watcher/' + $scope.watchers[$index]._id)
+      return $http.delete('../api/sentinl/watcher/' + $scope.watchers[$index]._id)
       .then(
         (resp) => {
           $timeout(function () {

--- a/public/controllers/reportController.js
+++ b/public/controllers/reportController.js
@@ -84,7 +84,7 @@ uiModules
 
   $scope.deleteReport = function (index, rmindex, rmtype, rmid) {
     if (confirm('Delete is Forever!\n Are you sure?')) {
-      return $http.get('../api/sentinl/delete/alarm/' + rmindex + '/' + rmtype + '/' + rmid)
+      return $http.delete('../api/sentinl/alarm/' + rmindex + '/' + rmtype + '/' + rmid)
       .then(() => {
         $scope.elasticReports.splice(index - 1, 1);
         $timeout(() => {

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -105,8 +105,8 @@ export default function routes(server) {
   });
 
   server.route({
-    method: 'GET',
-    path: '/api/sentinl/delete/alarm/{index}/{type}/{id}',
+    method: 'DELETE',
+    path: '/api/sentinl/alarm/{index}/{type}/{id}',
     handler: function (req, reply) {
       // Check if alarm index and discard everything else
       if (!req.params.index.substr(0, config.es.alarm_index.length) === config.es.alarm_index) {
@@ -218,8 +218,8 @@ export default function routes(server) {
   });
 
   server.route({
-    method: 'GET',
-    path: '/api/sentinl/delete/watcher/{id}',
+    method: 'DELETE',
+    path: '/api/sentinl/watcher/{id}',
     handler: function (req, reply) {
       var callWithRequest = server.plugins.elasticsearch.callWithRequest;
       var body = {


### PR DESCRIPTION
> Use PUT, POST and DELETE methods instead of the GET method to alter the state.

(cf. [REST API Best practices](https://saipraveenblog.wordpress.com/2014/09/29/rest-api-best-practices/))

In our case `DELETE` is better suited for deletion.

Manual tests performed 
- [x] Creation/Deletion of a `watcher` 
```
server    log   [19:45:12.210] [info][status][Sentinl] Saving Watcher with ID: new_watcher_08699wf02
server    log   [19:45:25.492] [info][status][Sentinl] Scheduled Watch: new_watcher_08699wf02 every every 5 minutes
server    log   [19:55:55.768] [info][status][Sentinl] Deleting orphan watcher: new_watcher_08699wf02

```
- [x] Creation/Deletion of a `watcher` 
```
server    log   [19:51:19.297] [info][status][Sentinl] Saving Watcher with ID: reporter_51lhxryxv
server    log   [19:55:55.769] [info][status][Sentinl] Deleting orphan watcher: reporter_51lhxryxv
```