### PR TITLE
Add path for Chrome executable. It is used by Report functionality.

### DIFF
--- a/docs/Config-Example.md
+++ b/docs/Config-Example.md
@@ -17,6 +17,7 @@ sentinl:
       ssl: true
     report:
       active: true
+      executable_path: '/usr/bin/chromium' # path to Chrome v59+ or Chromium v59+
 ```
 
 
@@ -67,6 +68,7 @@ sentinl:
       # method: POST
     report:
       active: true
+      executable_path: '/usr/bin/chromium' # path to Chrome v59+ or Chromium v59+
       timeout: 5000
       # authentication:
       #   enabled: true

--- a/docs/HOWTO-Create-Reports.md
+++ b/docs/HOWTO-Create-Reports.md
@@ -50,6 +50,7 @@ sentinl:
   settings:
     report:
       active: true
+      executable_path: '/usr/bin/chromium' # path to Chrome v59+ or Chromium v59+
 ```
 
 #### Report Away!


### PR DESCRIPTION
Merge **only** after [this commit](https://github.com/sirensolutions/sentinl-private/commit/4960bc78190285c6ef71a779347105086ee8703f) ported to master.