### PR TITLE
Fix undefined credentials reference for basic auth on reports

### DIFF
--- a/server/lib/actions/actions/report.js
+++ b/server/lib/actions/actions/report.js
@@ -100,7 +100,7 @@ class Reporter {
     }
 
     if (this.config.authentication.enabled && this.config.authentication.mode.basic) {
-      this.page = await Authenticator.basic(this.page, this.authentication.username, this.authentication.password);
+      this.page = await Authenticator.basic(this.page, this.config.authentication.username, this.config.authentication.password);
     }
 
     try {


### PR DESCRIPTION
Attempting to utilize basic auth inside reporting results in the following error:

```json
{
  "type": "log",
  "@timestamp": "2018-05-10T13:29:42Z",
  "tags": [
    "error",
    "Sentinl",
    "action"
  ],
  "pid": 1,
  "message": "report action: fail to execute report: Cannot read property 'username' of undefined"
}
```

The issue is the code on line 103 below and that it was accessing a never defined property `this.authentication`. The previous code was different than the other authentication mechanisms specified [on line 113](https://github.com/brandonwestcott/sentinl/blob/a95f948b31a0f2701b2f90bd8ef92ad0f6bfad93/server/lib/actions/actions/report.js#L113).

The change below resolves the error and makes the accessors consistent with the other authorization setups on line 113. 