### PR TITLE
Fixes for basic auth

### DIFF
--- a/server/lib/actions/actions/report.js
+++ b/server/lib/actions/actions/report.js
@@ -100,7 +100,7 @@ class Reporter {
     }
 
     if (this.config.authentication.enabled && this.config.authentication.mode.basic) {
-      this.page = await Authenticator.basic(this.page, this.config.authentication.username, this.config.authentication.password);
+      this.page = await Authenticator.basic(this.page, this.browser, this.config.authentication.username, this.config.authentication.password);
     }
 
     try {

--- a/server/lib/actions/actions/report.js
+++ b/server/lib/actions/actions/report.js
@@ -109,7 +109,7 @@ class Reporter {
       throw new Error(`fail to go to url: ${url}`);
     }
 
-    if (this.config.authentication.enabled) {
+    if (this.config.authentication.enabled && !this.config.authentication.mode.basic) {
       const {mode, username, password} = this.config.authentication;
       await this.authenticate(mode, username, password, this.config.timeout);
     } else {

--- a/server/lib/actions/actions/report.js
+++ b/server/lib/actions/actions/report.js
@@ -47,7 +47,7 @@ class Authenticator {
     try {
       await page.setExtraHTTPHeaders({
         Authorization: `Basic ${new Buffer(`${user}:${pass}`).toString(encoding)}`
-      })
+      });
       return page;
     } catch (err) {
       await browser.close();
@@ -98,7 +98,8 @@ class Reporter {
     }
 
     if (this.config.authentication.enabled && this.config.authentication.mode.basic) {
-      this.page = await Authenticator.basic(this.page, this.browser, this.config.authentication.username, this.config.authentication.password);
+      this.page = await Authenticator.basic(this.page, this.browser,
+        this.config.authentication.username, this.config.authentication.password);
     }
 
     try {

--- a/server/lib/actions/actions/report.js
+++ b/server/lib/actions/actions/report.js
@@ -26,7 +26,6 @@ class Authenticator {
 
       await delay(timeout);
       await page.click('.global-nav-link--close');
-      await delay(timeout);
     } catch (err) {
       await browser.close();
       throw new Error(`fail to authenticate via Search Guard, user: ${user}: ${err.message}`);
@@ -38,7 +37,6 @@ class Authenticator {
       await page.type(userSelector, user, {delay: timeout / 50});
       await page.type(passSelector, pass, {delay: timeout / 50});
       await page.click(loginBtnSelector);
-      await delay(timeout);
     } catch (err) {
       await browser.close();
       throw new Error(`fail to authenticate via custom auth, user: ${user}: ${err.message}`);
@@ -109,12 +107,12 @@ class Reporter {
       throw new Error(`fail to go to url: ${url}`);
     }
 
-    if (this.config.authentication.enabled && !this.config.authentication.mode.basic) {
+    if (this.config.authentication.enabled) {
       const {mode, username, password} = this.config.authentication;
       await this.authenticate(mode, username, password, this.config.timeout);
-    } else {
-      await delay(this.config.timeout);
     }
+
+    await delay(this.config.timeout);
   }
 
   async authenticate(mode, user, pass, timeout) {

--- a/server/lib/actions/actions/report.js
+++ b/server/lib/actions/actions/report.js
@@ -45,9 +45,9 @@ class Authenticator {
 
   static async basic(page, browser, user, pass, encoding = 'base64') {
     try {
-      const headers = new Map();
-      headers.set('Authorization', `Basic ${new Buffer(`${user}:${pass}`).toString(encoding)}`);
-      await page.setExtraHTTPHeaders(headers);
+      await page.setExtraHTTPHeaders({
+        Authorization: `Basic ${new Buffer(`${user}:${pass}`).toString(encoding)}`
+      })
       return page;
     } catch (err) {
       await browser.close();


### PR DESCRIPTION
A few "bugs" that were remaining inside of basic auth:

1) the method signature for `Authentication.basic` was changed [here](https://github.com/sirensolutions/sentinl/commit/96c998761ecfc7c3f484472f520d2b74bf229b7b#diff-4dccafcfbf5ba1a00f4f423d460d4baaL46), but the caller wasn't updated on 103 below.
2) When using basic auth, the screenshot delay was not being respected because of entering the if block on `112`, but basic not being dealt with on `this.authenticate`. Originally I had added an extra conditional (see https://github.com/sirensolutions/sentinl/commit/b58d669b5664d02957b8043e0f290c482bc807ff), but then aimed to simplify the logic using the implementation below. Simply just removed the final delay in each authenticator, and then made the final delay inside `openPage` always execute. 
3) `setExtraHTTPHeaders` accepts an object, not a map [as of 0.10.2](https://github.com/GoogleChrome/puppeteer/releases/tag/v0.10.2), see: https://github.com/GoogleChrome/puppeteer/blob/v1.3.0/docs/api.md#pagesetextrahttpheadersheaders.