### PR TITLE
Dynamic time ranges added to the spy widget. It defaults to using epoch sec.

### DIFF
--- a/public/dashboard_spy_button/alarm_button.js
+++ b/public/dashboard_spy_button/alarm_button.js
@@ -126,7 +126,6 @@ const dashboardSpyButton = function ($scope, config) {
                   }
                   newTimestamp.gte = 'now-' + relativeTime + timeUnits[largestUnit] + '/' + timeUnits[largestUnit];
                   newTimestamp.lte = 'now/' + timeUnits[largestUnit];
-                  //newTimestamp.format = must[key].range['@timestamp'].format.replace('millis','second');
                   alarm._source.input.search.request.body.query.bool.must[key].range['@timestamp'] = newTimestamp;
                 }
               }

--- a/public/dashboard_spy_button/alarm_button.js
+++ b/public/dashboard_spy_button/alarm_button.js
@@ -39,7 +39,7 @@ const dashboardSpyButton = function ($scope, config) {
     $scope.indices = [];
 
     if (req.fetchParams && req.fetchParams.index) {
-      const index = req.fetchParams.index.toString();
+      const index = req.fetchParams.index.title || req.fetchParams.index.toString();
       $scope.indices.push(index);
     }
 

--- a/public/dashboard_spy_button/alarm_button.js
+++ b/public/dashboard_spy_button/alarm_button.js
@@ -105,19 +105,19 @@ const dashboardSpyButton = function ($scope, config) {
                   let diff = new Date(end - start).getTime() / 1000; // UTC timestamp in seconds
                   let timeArray = getUTCArray(diff,timeFractions);
                   let largestUnit = 0;
-                  for(let i = 0; i < timeArray.length; ++i) {
+                  for (let i = 0; i < timeArray.length; ++i) {
                     //[s,min,hour,day,week] == input array [60,60,24,7]
                     largestUnit = i;
-                    if(timeArray[i] !== 0) {
+                    if (timeArray[i] !== 0) {
                       break;
                     }
                   }
                   let relativeTime = timeArray[largestUnit];// works as start time in the right unit
                   if (largestUnit <= timeArray.length) {
-                    for(let k = largestUnit + 1; k < timeArray.length; ++k) {
+                    for (let k = largestUnit + 1; k < timeArray.length; ++k) {
                       let timeSize = 1;
-                      if(timeArray[k] !== 0) {
-                        for(let g = k; g > largestUnit; --g) {
+                      if (timeArray[k] !== 0) {
+                        for (let g = k; g > largestUnit; --g) {
                           timeSize *= timeFractions[g - 1];
                         }
                       }


### PR DESCRIPTION
Uses epoch_second now! It compares the two (current epoch millis) timestamps provided, and after that it computes time between in seconds and uses this in the query.

Further improvements would include extracting data from ```indexPattern``` to handle the most common time fields (eg '@timestamp').

This closes https://github.com/sirensolutions/sentinl/issues/454