### PR TITLE
Wrong decision when transform script evaluated

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "sentinl",
   "version": "6.0.0",
   "kibana": {
-    "version": "6.2.3"
+    "version": "6.2.4"
   },
   "description": "Kibana Alert & Report App for Elasticsearch",
   "main": "index.js",


### PR DESCRIPTION
JS 'eval' returns 'undefined' when an object is updated. It is wrong to take a decision in transform based on 'eval' output. Any legitimate change to 'payload' results in 'undefined' and warning 'no data found'.

This closes #465 