### PR TITLE
Removed operator == for to use in the spy wizard.

### DIFF
--- a/public/pages/editor/editor.controller.js
+++ b/public/pages/editor/editor.controller.js
@@ -68,8 +68,7 @@ function EditorController(sentinlConfig, $rootScope, $scope, $route, $interval,
         {operator:  '>', name: 'Greater than'},
         {operator:  '<', name: 'Less than'},
         {operator: '>=', name: 'Greater than or equal'},
-        {operator: '<=', name: 'Less than or equal'},
-        {operator: '==', name: 'Equal'}
+        {operator: '<=', name: 'Less than or equal'}
       ];
       $scope.watcher.$$condition_operator = $scope.watcher.$$condition_operators[0].operator; // setting the default operator (gte)
     }


### PR DESCRIPTION
Removed the == operator because it may very well work against its purpose. When giving an option to specify == the users may very well want to use it, but depending on whether it hits or not depends on the rate of change and the trigger schedule.