### PR TITLE
Push Kibana Version to 5.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "url": "http://github.com/sirensolutions/sentinl.git"
   },
   "name": "sentinl",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "kibana": {
-    "version": "5.6.9"
+    "version": "5.6.10"
   },
   "description": "Kibana Alert & Report App for Elasticsearch",
   "main": "index.js",


### PR DESCRIPTION
Push Kibana version to 5.6.10 in package.json. Are there any additional changes necessary that also a release for Kibana 5.6.10 is build ? 